### PR TITLE
Feature: include guards uppercased

### DIFF
--- a/kwsCheckIfNDefDefine.cxx
+++ b/kwsCheckIfNDefDefine.cxx
@@ -12,13 +12,14 @@
 
 =========================================================================*/
 #include "kwsParser.h"
+#include <cctype>
 
 namespace kws {
 
 
 /** Check if the #ifndef/#define is defined correctly for the class 
  *  match can contain [NameOfClass] and [Extension] */
-bool Parser::CheckIfNDefDefine(const char* match)
+bool Parser::CheckIfNDefDefine(const char* match, bool uppercaseTheDefinition)
 {
   // Check only if we are not a .cxx or .cc or .c file
   if(m_Filename.find(".c") != std::string::npos)
@@ -171,6 +172,12 @@ bool Parser::CheckIfNDefDefine(const char* match)
       if(posnofc != -1)
         {
         toMatch.replace(posnofc,11,extension);
+        }
+
+      if(uppercaseTheDefinition)
+        {
+        for(std::string::iterator it = toMatch.begin(); it != toMatch.end(); it++)
+          *it = std::toupper(*it);
         }
 
       if(ifndef != toMatch)

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -438,7 +438,17 @@ bool Parser::Check(const char* name, const char* value)
     }
   else if(!strcmp(name,"IfNDefDefine"))
     {
-    this->CheckIfNDefDefine(value);
+    std::string val = value;
+    std::string v1 = value;
+    bool uppercaseTheDefinition = false;
+    long pos = val.find(",", 0);
+    if(pos != -1)
+      {
+      v1 = val.substr(0, pos);
+      std::string v2 = val.substr(pos+1);
+      uppercaseTheDefinition = !v2.compare("true") || !v2.compare("1");
+      }
+    this->CheckIfNDefDefine(v1.c_str(), uppercaseTheDefinition);
     }
   else if(!strcmp(name,"EmptyLines"))
     {

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -262,7 +262,7 @@ public:
   bool CheckHeader(const char* filename,bool considerSpaceEOL = true,bool useCVS=true);
 
   /** Check if the #ifndef/#define is defined correctly for the class */
-  bool CheckIfNDefDefine(const char* match);
+  bool CheckIfNDefDefine(const char* match, bool uppercaseTheDefinition);
 
   /** Check the first namespace in the file */
   bool CheckNamespace(const char* name,bool doNotCheckMain=true);

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -262,7 +262,7 @@ public:
   bool CheckHeader(const char* filename,bool considerSpaceEOL = true,bool useCVS=true);
 
   /** Check if the #ifndef/#define is defined correctly for the class */
-  bool CheckIfNDefDefine(const char* match, bool uppercaseTheDefinition);
+  bool CheckIfNDefDefine(const char* match, bool uppercaseTheDefinition=false);
 
   /** Check the first namespace in the file */
   bool CheckNamespace(const char* name,bool doNotCheckMain=true);


### PR DESCRIPTION
Added an option in the **IfNDefDefine** lint rule to optionally convert the pattern, consisting of filename/classname and extension to uppercase (e.g: **__TEST_H** from file **test.h**).

To use it, just add a nested option in the IfNDefDefine and set it to true or 1.

Except for the second test, **kwsRunKWStyleTest**, all tests are passing. **kwsRunKWStyleTest** is failing without my changes which indicates an unrelated problem (visual studio 2012 on windows).

Backward compatibility is maintained, the new option is off by default and not required in the xml file.
