### PR TITLE
Line numbers are supposed to be pre-calculated, they weren't.

### DIFF
--- a/kwsParser.h
+++ b/kwsParser.h
@@ -164,6 +164,20 @@ public:
     this->ConvertBufferToWindowsFileType(m_Buffer);
     m_FixedBuffer = m_Buffer;
     this->RemoveComments();
+
+    //Fill up the m_positions vector
+    m_Positions.clear();
+    m_Positions.push_back(0);
+    const char* currentCharacter = m_Buffer.c_str();
+    size_t currentPosition = 0;
+    while( *currentCharacter )
+      {
+      if( (*currentCharacter) == '\n' )
+        m_Positions.push_back(currentPosition);
+      currentPosition++;
+      currentCharacter++;
+      }
+    m_Positions.push_back(currentPosition);
     }
  
   /** Return the error tag as string given the error number */


### PR DESCRIPTION
Now they are. 
Except for the second test, **kwsRunKWStyleTest**, all tests are passing. **kwsRunKWStyleTest** is failing without my changes which indicates an unrelated problem (visual studio 2012 on windows).

**Details**:
**Parser::GetLineNumber(...)** depended on that behavior so it failed except when the Line length lint rule was called before anyone tried to retrieve line numbers (it initialized the line numbers' vector).
