### PR TITLE
Added new lint rule to forbid relative path in includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,6 +79,7 @@ kwsCheckVariables.cxx
 kwsCheckMemberFunctions.cxx
 kwsCheckFunctions.cxx
 kwsCheckUsingDirectives.cxx
+kwsCheckRelativePathInInclude.cxx
 )
 
 SUBDIRS(Utilities)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ kwsCheckStruct.cxx
 kwsCheckVariables.cxx
 kwsCheckMemberFunctions.cxx
 kwsCheckFunctions.cxx
+kwsCheckUsingDirectives.cxx
 )
 
 SUBDIRS(Utilities)

--- a/kwsCheckRelativePathInInclude.cxx
+++ b/kwsCheckRelativePathInInclude.cxx
@@ -1,0 +1,54 @@
+/*=========================================================================
+
+  Program:   KWStyle - Kitware Style Checker
+  Module:    kwsCheckUsingDirectives.cxx
+
+  Copyright (c) Kitware, Inc.  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "kwsParser.h"
+
+namespace kws {
+
+/** Check if the file contains includes with paths that refer to parent directory (ie: #include "../folder/file.h" ) */
+bool Parser::CheckRelativePathInInclude(bool forbidRelativePaths)
+{
+  if(!forbidRelativePaths)
+    return true;
+
+  bool hasError = false;
+  size_t includePos = m_BufferNoComment.find("#include", 0);
+  while( (includePos = m_BufferNoComment.find("#include", includePos)) != std::string::npos)
+    {
+    if(this->IsBetweenQuote(includePos, false))
+      {
+      includePos += 8;
+      continue;
+      }
+
+    size_t newlinePos = m_BufferNoComment.find('\n', includePos);
+    size_t parentDirPos = m_BufferNoComment.find("..", includePos);
+
+    if(parentDirPos != std::string::npos && 
+        ( (newlinePos != std::string::npos && parentDirPos < newlinePos) || newlinePos == std::string::npos )
+      )
+      {
+      hasError = true;
+      Error error;
+      error.line = this->GetLineNumber(includePos, true);
+      error.line2 = error.line;
+      error.description = "#include refers to a parent directory in the path.";
+      error.number = RELATIVE_PATH_IN_INCLUDE;
+      m_ErrorList.push_back(error);
+      }
+    includePos += 8;
+    }
+  return !hasError;
+}
+
+} // end namespace kws

--- a/kwsCheckUsingDirectives.cxx
+++ b/kwsCheckUsingDirectives.cxx
@@ -12,6 +12,7 @@
 
 =========================================================================*/
 #include "kwsParser.h"
+#include <cctype>
 
 namespace kws {
 
@@ -22,22 +23,71 @@ bool Parser::CheckUsingDirectives(bool forbidUsingDirectives)
     return true;
 
   bool hasError = false;
-  const char * ptr = m_BufferNoComment.c_str();
-  kwssys::RegularExpression regex("using[ \r\n\t]+namespace[ \r\n\t]+[A-Za-z_]+[ \r\n\t]*;");
-  while(ptr && regex.find(ptr))
-    {
-    ptr = m_BufferNoComment.c_str() + regex.end();
-    if(this->IsBetweenQuote(regex.start(), false))
-      continue;
 
-    hasError = true;
-    Error error;
-    error.line = this->GetLineNumber(regex.start(), true);
-    error.line2 = error.line;
-    error.description = "Using namespace directive used.";
-    error.number = USING_DIRECTIVES;
-    m_ErrorList.push_back(error);
+  size_t usingPos = m_BufferNoComment.find("using");
+  while( usingPos != std::string::npos )
+    {
+    size_t tempIndex = usingPos += 5;//points right after "using"
+    if(this->IsBetweenQuote(usingPos, false))
+      {
+      usingPos = m_BufferNoComment.find("using", tempIndex);
+      continue;
+      }
+
+    //Munch whitespace (at least one character)
+    int whitespaceCharacterCount = 0;
+    while(tempIndex < m_BufferNoComment.size() && isspace(m_BufferNoComment[tempIndex]))
+      {
+      tempIndex++;
+      whitespaceCharacterCount++;
+      }
+    if( tempIndex >= m_BufferNoComment.size() || whitespaceCharacterCount < 1 )//file ended or not enough whitespace characters
+      return true;
+
+    //Munch "namespace"
+    if(m_BufferNoComment.substr(tempIndex, 9) != "namespace")
+      {
+      usingPos = m_BufferNoComment.find("using", tempIndex);
+      continue;
+      }
+    tempIndex += 9;//points right after "namespace"
+
+    //Munch whitespace (at least one character)
+    whitespaceCharacterCount = 0;
+    while(tempIndex < m_BufferNoComment.size() && isspace(m_BufferNoComment[tempIndex]))
+      {
+      tempIndex++;
+      whitespaceCharacterCount++;
+      }
+    if( tempIndex >= m_BufferNoComment.size() || whitespaceCharacterCount < 1 )//file ended or not enough whitespace characters
+      return true;
+
+    //Munch identifier
+    while(tempIndex < m_BufferNoComment.size() && (isalpha(m_BufferNoComment[tempIndex]) || m_BufferNoComment[tempIndex] == '_') )
+      tempIndex++;
+    if( tempIndex >= m_BufferNoComment.size() )//file ended
+      return true;
+
+    //Munch whitespace
+    while(tempIndex < m_BufferNoComment.size() && isspace(m_BufferNoComment[tempIndex]))
+      tempIndex++;
+    if( tempIndex >= m_BufferNoComment.size() )//file ended
+      return true;
+
+    if(m_BufferNoComment[tempIndex] == ';')//Match found for the full "using namespace [A-Za-z_]+;"
+      {
+      hasError = true;
+      Error error;
+      error.line = this->GetLineNumber(usingPos, true);
+      error.line2 = error.line;
+      error.description = "Using namespace directive used.";
+      error.number = USING_DIRECTIVES;
+      m_ErrorList.push_back(error);
+      }
+
+    usingPos = m_BufferNoComment.find("using", tempIndex);
     }
+
   return !hasError;
 }
 

--- a/kwsCheckUsingDirectives.cxx
+++ b/kwsCheckUsingDirectives.cxx
@@ -27,7 +27,7 @@ bool Parser::CheckUsingDirectives(bool forbidUsingDirectives)
   size_t usingPos = m_BufferNoComment.find("using");
   while( usingPos != std::string::npos )
     {
-    size_t tempIndex = usingPos += 5;//points right after "using"
+    size_t tempIndex = usingPos + 5;//points right after "using"
     if(this->IsBetweenQuote(usingPos, false))
       {
       usingPos = m_BufferNoComment.find("using", tempIndex);

--- a/kwsCheckUsingDirectives.cxx
+++ b/kwsCheckUsingDirectives.cxx
@@ -26,7 +26,7 @@ bool Parser::CheckUsingDirectives(bool forbidUsingDirectives)
   kwssys::RegularExpression regex("using[ \r\n\t]+namespace[ \r\n\t]+[A-Za-z_]+[ \r\n\t]*;");
   while(ptr && regex.find(ptr))
     {
-    ptr = m_BufferNoComment.c_str() + regex.end() + 1;
+    ptr = m_BufferNoComment.c_str() + regex.end();
     if(this->IsBetweenQuote(regex.start(), false))
       continue;
 

--- a/kwsCheckUsingDirectives.cxx
+++ b/kwsCheckUsingDirectives.cxx
@@ -1,0 +1,44 @@
+/*=========================================================================
+
+  Program:   KWStyle - Kitware Style Checker
+  Module:    kwsCheckUsingDirectives.cxx
+
+  Copyright (c) Kitware, Inc.  All rights reserved.
+  See Copyright.txt or http://www.kitware.com/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#include "kwsParser.h"
+
+namespace kws {
+
+/** Check if the file contains "using namespace .* ;" */
+bool Parser::CheckUsingDirectives(bool forbidUsingDirectives)
+{
+  if(!forbidUsingDirectives)
+    return true;
+
+  bool hasError = false;
+  const char * ptr = m_BufferNoComment.c_str();
+  kwssys::RegularExpression regex("using[ \r\n\t]+namespace[ \r\n\t]+[A-Za-z_]+[ \r\n\t]*;");
+  while(ptr && regex.find(ptr))
+    {
+    ptr = m_BufferNoComment.c_str() + regex.end() + 1;
+    if(this->IsBetweenQuote(regex.start(), false))
+      continue;
+
+    hasError = true;
+    Error error;
+    error.line = this->GetLineNumber(regex.start(), true);
+    error.line2 = error.line;
+    error.description = "Using namespace directive used.";
+    error.number = USING_DIRECTIVES;
+    m_ErrorList.push_back(error);
+    }
+  return !hasError;
+}
+
+} // end namespace kws

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -472,6 +472,13 @@ bool Parser::Check(const char* name, const char* value)
       forbidUsingDirectives = false;
     this->CheckUsingDirectives(forbidUsingDirectives);
     }
+  else if(!strcmp(name, "RelativePathInInclude"))
+    {
+    bool forbidRelativePaths = true;
+    if( !strcmp(value, "0") || !strcmp(value, "false"))
+      forbidRelativePaths = false;
+    this->CheckRelativePathInInclude(forbidRelativePaths);
+    }
   return false;
 }
 

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -465,6 +465,13 @@ bool Parser::Check(const char* name, const char* value)
     {
     this->CheckBlackList(value);
     }
+  else if(!strcmp(name, "UsingDirectives"))
+    {
+    bool forbidUsingDirectives = true;
+    if( !strcmp(value, "0") || !strcmp(value, "false"))
+      forbidUsingDirectives = false;
+    this->CheckUsingDirectives(forbidUsingDirectives);
+    }
   return false;
 }
 

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -29,7 +29,7 @@
 namespace kws
 {
 #define MAX_CHAR 99999999
-#define NUMBER_ERRORS 33
+#define NUMBER_ERRORS 34
 
 typedef enum
   {
@@ -71,7 +71,8 @@ typedef enum
   MEMBERFUNCTION_LENGTH,
   FUNCTION_REGEX,
   FUNCTION_LENGTH,
-  USING_DIRECTIVES
+  USING_DIRECTIVES,
+  RELATIVE_PATH_IN_INCLUDE
   } ErrorType;
 
 const char ErrorTag[NUMBER_ERRORS][4] = {
@@ -107,7 +108,8 @@ const char ErrorTag[NUMBER_ERRORS][4] = {
    {'M','F','L','\0'},
    {'F','R','G','\0'},
    {'F','L','N','\0'},
-   {'U','N','D','\0'}
+   {'U','N','D','\0'},
+   {'R','P','I','\0'}
   };
 
 
@@ -185,6 +187,9 @@ public:
 
   /** Check if the file contains "using namespace .* ;" */
   bool CheckUsingDirectives(bool forbidUsingDirectives);
+
+  /** Check if the file contains includes with paths that refer to parent directory (ie: #include "../folder/file.h" ) */
+  bool CheckRelativePathInInclude(bool forbidRelativePaths);
 
   /** Check if the file contains tabs */
   bool CheckTabs();

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -29,7 +29,7 @@
 namespace kws
 {
 #define MAX_CHAR 99999999
-#define NUMBER_ERRORS 32
+#define NUMBER_ERRORS 33
 
 typedef enum
   {
@@ -70,7 +70,8 @@ typedef enum
   MEMBERFUNCTION_REGEX,
   MEMBERFUNCTION_LENGTH,
   FUNCTION_REGEX,
-  FUNCTION_LENGTH
+  FUNCTION_LENGTH,
+  USING_DIRECTIVES
   } ErrorType;
 
 const char ErrorTag[NUMBER_ERRORS][4] = {
@@ -105,7 +106,8 @@ const char ErrorTag[NUMBER_ERRORS][4] = {
    {'M','B','F','\0'},
    {'M','F','L','\0'},
    {'F','R','G','\0'},
-   {'F','L','N','\0'}
+   {'F','L','N','\0'},
+   {'U','N','D','\0'}
   };
 
 
@@ -180,6 +182,9 @@ public:
 
   /** Return the warning vector */
   const WarningVectorType & GetWarnings() const {return m_WarningList;}
+
+  /** Check if the file contains "using namespace .* ;" */
+  bool CheckUsingDirectives(bool forbidUsingDirectives);
 
   /** Check if the file contains tabs */
   bool CheckTabs();

--- a/kwsStyle.cxx
+++ b/kwsStyle.cxx
@@ -187,6 +187,7 @@ int main(int argc, char **argv)
   AddFeature("MemberFunctions","*",true);
   AddFeature("Functions","*",true);
   AddFeature("UsingDirectives", "true", true);
+  AddFeature("RelativePathInInclude", "true", true);
 
   std::string xmlFile = "KWStyle.xml";
   // If we should look the definition from the xml file

--- a/kwsStyle.cxx
+++ b/kwsStyle.cxx
@@ -186,6 +186,7 @@ int main(int argc, char **argv)
   AddFeature("BadCharacters","true",true);
   AddFeature("MemberFunctions","*",true);
   AddFeature("Functions","*",true);
+  AddFeature("UsingDirectives", "true", true);
 
   std::string xmlFile = "KWStyle.xml";
   // If we should look the definition from the xml file


### PR DESCRIPTION
It forbids the usage of this form __"../folder/file.h"__

### Rule details:
__XML tag key text:__ RelativePathInInclude
__XML tag value:__ (0 or false to not forbid relative path up access; anything else to forbid them.), it's on by default
__Error type:__ RELATIVE_PATH_IN_INCLUDE
__Error tag:__ RPI
__New function:__ CheckRelativePathInInclude

__Tests:__
Except for the second test, kwsRunKWStyleTest, all tests are passing. kwsRunKWStyleTest is failing without my changes which indicates an unrelated problem (visual studio 2012 on windows).

__Note:__
This branch is based off the one in pull request #8, so it includes 2 features.
Pull request #7 needs to be applied for the line numbers to be calculated correctly or use the LineLength rule before this one in the xml file.