### PR TITLE
COMP: Updated the boost library and Fixed warning messages of KWStyle 

### DIFF
--- a/Testing/kwsRunKWStyleTest.cxx
+++ b/Testing/kwsRunKWStyleTest.cxx
@@ -9,8 +9,8 @@
   Copyright (c) Insight Software Consortium. All rights reserved.
   See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
 
-     This software is distributed WITHOUT ANY WARRANTY; without even 
-     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     This software is distributed WITHOUT ANY WARRANTY; without even
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
@@ -21,7 +21,7 @@
 #include <iostream>
 #include <kwssys/Process.h>
 
-int kwsRunKWStyleTest(int argc, char* argv[] )
+int kwsRunKWStyleTest(int , char* argv[] )
 {
   argv++;
 

--- a/Utilities/KWSys/CommandLineArguments.cxx
+++ b/Utilities/KWSys/CommandLineArguments.cxx
@@ -62,12 +62,12 @@ struct CommandLineArgumentsCallbackStructure
   int VariableType;
   const char* Help;
 };
- 
-class CommandLineArgumentsVectorOfStrings : 
+
+class CommandLineArgumentsVectorOfStrings :
   public std::vector<kwsys::String> {};
 class CommandLineArgumentsSetOfStrings :
   public std::set<kwsys::String> {};
-class CommandLineArgumentsMapOfStrucs : 
+class CommandLineArgumentsMapOfStrucs :
   public std::map<kwsys::String,
     CommandLineArgumentsCallbackStructure> {};
 
@@ -163,7 +163,7 @@ bool CommandLineArguments::GetMatchedArguments(
     const CommandLineArguments::Internal::String& parg = it->first;
     CommandLineArgumentsCallbackStructure *cs = &it->second;
     if (cs->ArgumentType == CommandLineArguments::NO_ARGUMENT ||
-      cs->ArgumentType == CommandLineArguments::SPACE_ARGUMENT) 
+      cs->ArgumentType == CommandLineArguments::SPACE_ARGUMENT)
       {
       if ( arg == parg )
         {
@@ -209,7 +209,7 @@ int CommandLineArguments::Parse()
         }
       // So, the longest one is probably the right one. Now see if it has any
       // additional value
-      CommandLineArgumentsCallbackStructure *cs 
+      CommandLineArgumentsCallbackStructure *cs
         = &this->Internals->Callbacks[matches[maxidx]];
       const std::string& sarg = matches[maxidx];
       if ( cs->Argument != sarg )
@@ -295,7 +295,7 @@ int CommandLineArguments::Parse()
       // Handle unknown arguments
       if ( this->Internals->UnknownArgumentCallback )
         {
-        if ( !this->Internals->UnknownArgumentCallback(arg.c_str(), 
+        if ( !this->Internals->UnknownArgumentCallback(arg.c_str(),
             this->Internals->ClientData) )
           {
           this->Internals->LastArgument --;
@@ -322,7 +322,7 @@ int CommandLineArguments::Parse()
 //----------------------------------------------------------------------------
 void CommandLineArguments::GetRemainingArguments(int* argc, char*** argv)
 {
-  CommandLineArguments::Internal::VectorOfStrings::size_type size 
+  CommandLineArguments::Internal::VectorOfStrings::size_type size
     = this->Internals->Argv.size() - this->Internals->LastArgument + 1;
   CommandLineArguments::Internal::VectorOfStrings::size_type cc;
 
@@ -333,7 +333,7 @@ void CommandLineArguments::GetRemainingArguments(int* argc, char*** argv)
   int cnt = 1;
 
   // Copy everything after the LastArgument, since that was not parsed.
-  for ( cc = this->Internals->LastArgument+1; 
+  for ( cc = this->Internals->LastArgument+1;
     cc < this->Internals->Argv.size(); cc ++ )
     {
     args[cnt] = new char[ this->Internals->Argv[cc].size() + 1];
@@ -347,7 +347,7 @@ void CommandLineArguments::GetRemainingArguments(int* argc, char*** argv)
 //----------------------------------------------------------------------------
 void CommandLineArguments::GetUnusedArguments(int* argc, char*** argv)
 {
-  CommandLineArguments::Internal::VectorOfStrings::size_type size 
+  CommandLineArguments::Internal::VectorOfStrings::size_type size
     = this->Internals->UnusedArguments.size() + 1;
   CommandLineArguments::Internal::VectorOfStrings::size_type cc;
 
@@ -382,7 +382,7 @@ void CommandLineArguments::DeleteRemainingArguments(int argc, char*** argv)
 }
 
 //----------------------------------------------------------------------------
-void CommandLineArguments::AddCallback(const char* argument, ArgumentTypeEnum type, 
+void CommandLineArguments::AddCallback(const char* argument, ArgumentTypeEnum type,
   CallbackType callback, void* call_data, const char* help)
 {
   CommandLineArgumentsCallbackStructure s;
@@ -466,7 +466,7 @@ void CommandLineArguments::SetUnknownArgumentCallback(
 //----------------------------------------------------------------------------
 const char* CommandLineArguments::GetHelp(const char* arg)
 {
-  CommandLineArguments::Internal::CallbacksMap::iterator it 
+  CommandLineArguments::Internal::CallbacksMap::iterator it
     = this->Internals->Callbacks.find(arg);
   if ( it == this->Internals->Callbacks.end() )
     {
@@ -478,7 +478,7 @@ const char* CommandLineArguments::GetHelp(const char* arg)
   CommandLineArgumentsCallbackStructure *cs = &(it->second);
   for(;;)
     {
-    CommandLineArguments::Internal::CallbacksMap::iterator hit 
+    CommandLineArguments::Internal::CallbacksMap::iterator hit
       = this->Internals->Callbacks.find(cs->Help);
     if ( hit == this->Internals->Callbacks.end() )
       {
@@ -516,7 +516,7 @@ unsigned int CommandLineArguments::GetLastArgument()
 void CommandLineArguments::GenerateHelp()
 {
   std::ostringstream str;
-  
+
   // Collapse all arguments into the map of vectors of all arguments that do
   // the same thing.
   CommandLineArguments::Internal::CallbacksMap::iterator it;
@@ -562,7 +562,7 @@ void CommandLineArguments::GenerateHelp()
       mp[it->first].insert(it->first);
       }
     }
- 
+
   // Find the length of the longest string
   CommandLineArguments::Internal::String::size_type maxlen = 0;
   for ( mpit = mp.begin();
@@ -587,10 +587,6 @@ void CommandLineArguments::GenerateHelp()
       }
     }
 
-  // Create format for that string
-  char format[80];
-  sprintf(format, "  %%-%us  ", static_cast<unsigned int>(maxlen));
-
   maxlen += 4; // For the space before and after the option
 
   // Print help for each option
@@ -612,9 +608,7 @@ void CommandLineArguments::GenerateHelp()
         case CommandLineArguments::EQUAL_ARGUMENT:  strcat(argument, "=opt"); break;
         case CommandLineArguments::MULTI_ARGUMENT:  strcat(argument, " opt opt ..."); break;
         }
-      char buffer[80];
-      sprintf(buffer, format, argument);
-      str << buffer;
+      str << "  " << argument << "  ";
       }
     const char* ptr = this->Internals->Callbacks[mpit->first].Help;
     size_t len = strlen(ptr);

--- a/Utilities/boost/optional/optional.hpp
+++ b/Utilities/boost/optional/optional.hpp
@@ -190,9 +190,9 @@ void prevent_binding_rvalue_ref_to_optional_lvalue_ref()
 {
 #ifndef BOOST_OPTIONAL_CONFIG_ALLOW_BINDING_TO_RVALUES
   BOOST_STATIC_ASSERT_MSG(
-    !boost::is_lvalue_reference<To>::value || !boost::is_rvalue_reference<From>::value, 
+    !boost::is_lvalue_reference<To>::value || !boost::is_rvalue_reference<From>::value,
     "binding rvalue references to optional lvalue references is disallowed");
-#endif    
+#endif
 }
 
 struct optional_tag {} ;
@@ -345,7 +345,7 @@ class optional_base : public optional_tag
           construct(rhs.get_impl());
       }
     }
-    
+
 #ifndef BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Assigns from another optional<T> (deep-moves the rhs value)
     void assign ( optional_base&& rhs )
@@ -362,7 +362,7 @@ class optional_base : public optional_tag
           construct(boost::move(rhs.get_impl()));
       }
     }
-#endif 
+#endif
 
     // Assigns from another _convertible_ optional<U> (deep-copies the rhs value)
     template<class U>
@@ -376,7 +376,7 @@ class optional_base : public optional_tag
 #else
           assign_value(static_cast<value_type>(rhs.get()), is_reference_predicate() );
 #endif
-          
+
         else destroy();
       }
       else
@@ -409,7 +409,7 @@ class optional_base : public optional_tag
       }
     }
 #endif
-    
+
     // Assigns from a T (deep-copies the rhs value)
     void assign ( argument_type val )
     {
@@ -417,7 +417,7 @@ class optional_base : public optional_tag
            assign_value(val, is_reference_predicate() );
       else construct(val);
     }
-    
+
 #ifndef BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Assigns from a T (deep-moves the rhs value)
     void assign ( rval_reference_type val )
@@ -478,7 +478,7 @@ class optional_base : public optional_tag
        ::new (m_storage.address()) internal_type(val) ;
        m_initialized = true ;
      }
-     
+
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     void construct ( rval_reference_type val )
      {
@@ -514,7 +514,7 @@ class optional_base : public optional_tag
        ::new (m_storage.address()) internal_type( arg );
        m_initialized = true ;
      }
-     
+
      template<class Arg>
     void emplace_assign ( Arg& arg )
      {
@@ -786,7 +786,7 @@ class optional : public optional_detail::optional_base<T>
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Creates an optional<T> initialized with 'move(val)'.
     // Can throw if T::T(T &&) does
-    optional ( rval_reference_type val ) : base( boost::forward<T>(val) ) 
+    optional ( rval_reference_type val ) : base( boost::forward<T>(val) )
       {optional_detail::prevent_binding_rvalue_ref_to_optional_lvalue_ref<T, rval_reference_type>();}
 #endif
 
@@ -807,7 +807,7 @@ class optional : public optional_detail::optional_base<T>
       if ( rhs.is_initialized() )
         this->construct(rhs.get());
     }
-    
+
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Creates a deep move of another convertible optional<U>
     // Requires a valid conversion from U to T.
@@ -836,12 +836,12 @@ class optional : public optional_detail::optional_base<T>
 
 
   template<class Expr>
-  explicit optional ( Expr&& expr, 
+  explicit optional ( Expr&& expr,
                       BOOST_DEDUCED_TYPENAME boost::disable_if_c<
-                        (boost::is_base_of<optional_detail::optional_tag, BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type>::value) || 
-                        boost::is_same<BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type, none_t>::value >::type* = 0 
-  ) 
-    : base(boost::forward<Expr>(expr),boost::addressof(expr)) 
+                        (boost::is_base_of<optional_detail::optional_tag, BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type>::value) ||
+                        boost::is_same<BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type, none_t>::value >::type* = 0
+  )
+    : base(boost::forward<Expr>(expr),boost::addressof(expr))
     {optional_detail::prevent_binding_rvalue_ref_to_optional_lvalue_ref<T, Expr&&>();}
 
 #else
@@ -857,9 +857,9 @@ class optional : public optional_detail::optional_base<T>
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
 	// Creates a deep move of another optional<T>
 	// Can throw if T::T(T&&) does
-	optional ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
-	  : base( boost::move(rhs) ) 
+	optional ( optional && rhs )
+		BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value)
+		: base( boost::move(rhs) )
 	{}
 
 #endif
@@ -873,10 +873,10 @@ class optional : public optional_detail::optional_base<T>
 
     template<class Expr>
     BOOST_DEDUCED_TYPENAME boost::disable_if_c<
-      boost::is_base_of<optional_detail::optional_tag, BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type>::value || 
+      boost::is_base_of<optional_detail::optional_tag, BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type>::value ||
         boost::is_same<BOOST_DEDUCED_TYPENAME boost::decay<Expr>::type, none_t>::value,
       optional&
-    >::type 
+    >::type
     operator= ( Expr&& expr )
       {
         optional_detail::prevent_binding_rvalue_ref_to_optional_lvalue_ref<T, Expr&&>();
@@ -903,7 +903,7 @@ class optional : public optional_detail::optional_base<T>
         this->assign(rhs);
         return *this ;
       }
-      
+
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Move-assigns from another convertible optional<U> (converts && deep-moves the rhs value)
     // Requires a valid conversion from U to T.
@@ -927,8 +927,8 @@ class optional : public optional_detail::optional_base<T>
 
 #ifndef  BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     // Assigns from another optional<T> (deep-moves the rhs value)
-    optional& operator= ( optional && rhs ) 
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+    optional& operator= ( optional && rhs )
+    BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
       {
         this->assign( static_cast<base &&>(rhs) ) ;
         return *this ;
@@ -961,7 +961,7 @@ class optional : public optional_detail::optional_base<T>
         this->assign( none_ ) ;
         return *this ;
       }
-      
+
 #if (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES) && (!defined BOOST_NO_CXX11_VARIADIC_TEMPLATES)
     // Constructs in-place
     // upon exception *this is always uninitialized
@@ -982,7 +982,7 @@ class optional : public optional_detail::optional_base<T>
      {
        this->emplace_assign( arg );
      }
-     
+
     template<class Arg>
     void emplace ( Arg& arg )
      {
@@ -990,12 +990,12 @@ class optional : public optional_detail::optional_base<T>
      }
 #endif
 
-    void swap( optional & arg )
-	  BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
-      {
-        // allow for Koenig lookup
-        boost::swap(*this, arg);
-      }
+		void swap( optional & arg )
+		BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && ::boost::is_nothrow_move_assignable<T>::value)
+			{
+				// allow for Koenig lookup
+				boost::swap(*this, arg);
+			}
 
 
     // Returns a reference to the value if this is initialized, otherwise,
@@ -1017,7 +1017,7 @@ class optional : public optional_detail::optional_base<T>
     // Returns a reference to the value if this is initialized, otherwise,
     // the behaviour is UNDEFINED
     // No-throw
-#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES) 
+#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES)
     reference_const_type operator *() const& { return this->get() ; }
     reference_type       operator *() &      { return this->get() ; }
     reference_type_of_temporary_wrapper operator *() && { return base::types::move(this->get()) ; }
@@ -1026,42 +1026,42 @@ class optional : public optional_detail::optional_base<T>
     reference_type       operator *()       { return this->get() ; }
 #endif // !defined BOOST_NO_CXX11_REF_QUALIFIERS
 
-#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES) 
+#if (!defined BOOST_NO_CXX11_REF_QUALIFIERS) && (!defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES)
     reference_const_type value() const&
-      { 
+      {
         if (this->is_initialized())
           return this->get() ;
         else
           throw_exception(bad_optional_access());
       }
-      
+
     reference_type value() &
-      { 
+      {
         if (this->is_initialized())
           return this->get() ;
         else
           throw_exception(bad_optional_access());
       }
-      
+
     reference_type_of_temporary_wrapper value() &&
-      { 
+      {
         if (this->is_initialized())
           return base::types::move(this->get()) ;
         else
           throw_exception(bad_optional_access());
       }
 
-#else 
+#else
     reference_const_type value() const
-      { 
+      {
         if (this->is_initialized())
           return this->get() ;
         else
           throw_exception(bad_optional_access());
       }
-      
+
     reference_type value()
-      { 
+      {
         if (this->is_initialized())
           return this->get() ;
         else
@@ -1073,16 +1073,16 @@ class optional : public optional_detail::optional_base<T>
 #ifndef BOOST_NO_CXX11_REF_QUALIFIERS
     template <class U>
     value_type value_or ( U&& v ) const&
-      { 
+      {
         if (this->is_initialized())
           return get();
         else
           return boost::forward<U>(v);
       }
-    
+
     template <class U>
-    value_type value_or ( U&& v ) && 
-      { 
+    value_type value_or ( U&& v ) &&
+      {
         if (this->is_initialized())
           return base::types::move(get());
         else
@@ -1090,7 +1090,7 @@ class optional : public optional_detail::optional_base<T>
       }
 #elif !defined BOOST_OPTIONAL_DETAIL_NO_RVALUE_REFERENCES
     template <class U>
-    value_type value_or ( U&& v ) const 
+    value_type value_or ( U&& v ) const
       {
         if (this->is_initialized())
           return get();
@@ -1099,17 +1099,17 @@ class optional : public optional_detail::optional_base<T>
       }
 #else
     template <class U>
-    value_type value_or ( U const& v ) const 
-      { 
+    value_type value_or ( U const& v ) const
+      {
         if (this->is_initialized())
           return get();
         else
           return v;
       }
-      
+
     template <class U>
-    value_type value_or ( U& v ) const 
-      { 
+    value_type value_or ( U& v ) const
+      {
         if (this->is_initialized())
           return get();
         else
@@ -1127,7 +1127,7 @@ class optional : public optional_detail::optional_base<T>
         else
           return f();
       }
-      
+
     template <typename F>
     value_type value_or_eval ( F f ) &&
       {
@@ -1146,9 +1146,9 @@ class optional : public optional_detail::optional_base<T>
           return f();
       }
 #endif
-      
+
     bool operator!() const BOOST_NOEXCEPT { return !this->is_initialized() ; }
-    
+
     BOOST_EXPLICIT_OPERATOR_BOOL_NOEXCEPT()
 } ;
 
@@ -1248,13 +1248,13 @@ get_pointer ( optional<T>& opt )
   return opt.get_ptr() ;
 }
 
-// The following declaration prevents a bug where operator safe-bool is used upon streaming optional object if you forget the IO header.
-template<class CharType, class CharTrait>
-std::basic_ostream<CharType, CharTrait>&
-operator<<(std::basic_ostream<CharType, CharTrait>& out, optional_detail::optional_tag const& v)
-{
-  BOOST_STATIC_ASSERT_MSG(sizeof(CharType) == 0, "If you want to output boost::optional, include header <boost/optional/optional_io.hpp>"); 
-}
+//// The following declaration prevents a bug where operator safe-bool is used upon streaming optional object if you forget the IO header.
+//template<class CharType, class CharTrait>
+//std::basic_ostream<CharType, CharTrait>&
+//operator<<(std::basic_ostream<CharType, CharTrait>& out, optional_detail::optional_tag const& v)
+//{
+//  BOOST_STATIC_ASSERT_MSG(sizeof(CharType) == 0, "If you want to output boost::optional, include header <boost/optional/optional_io.hpp>");
+//}
 
 // optional's relational operators ( ==, !=, <, >, <=, >= ) have deep-semantics (compare values).
 // WARNING: This is UNLIKE pointers. Use equal_pointees()/less_pointess() in generic code instead.
@@ -1467,7 +1467,7 @@ template<>
 struct swap_selector<false>
 {
     template<class T>
-    static void optional_swap ( optional<T>& x, optional<T>& y ) 
+    static void optional_swap ( optional<T>& x, optional<T>& y )
     //BOOST_NOEXCEPT_IF(::boost::is_nothrow_move_constructible<T>::value && BOOST_NOEXCEPT_EXPR(boost::swap(*x, *y)))
     {
         if(x)

--- a/Utilities/boost/utility/base_from_member.hpp
+++ b/Utilities/boost/utility/base_from_member.hpp
@@ -142,8 +142,8 @@ protected:
         : member()
         {}
 
-    BOOST_PP_REPEAT_FROM_TO( 1, BOOST_PP_INC(BOOST_BASE_FROM_MEMBER_MAX_ARITY),
-     BOOST_PRIVATE_CTR_DEF, _ )
+//    BOOST_PP_REPEAT_FROM_TO( 1, BOOST_PP_INC(BOOST_BASE_FROM_MEMBER_MAX_ARITY),
+//     BOOST_PRIVATE_CTR_DEF, _ )
 #endif
 
 };  // boost::base_from_member

--- a/kwsCheckInternalVariables.cxx
+++ b/kwsCheckInternalVariables.cxx
@@ -51,7 +51,7 @@ bool Parser::CheckInternalVariables(const char* regEx,bool alignment,bool checkP
 
     size_t previousline = 0;
     size_t previouspos = 0;
-    
+
     size_t pos = publicFirst;
     while(pos!= std::string::npos)
       {
@@ -78,7 +78,7 @@ bool Parser::CheckInternalVariables(const char* regEx,bool alignment,bool checkP
           m_ErrorList.push_back(error);
           hasError = true;
           }
-        
+
         // Check the alignment if specified
         if(alignment)
           {
@@ -140,7 +140,7 @@ bool Parser::CheckInternalVariables(const char* regEx,bool alignment,bool checkP
         {
         continue;
         }
-   
+
       if(this->IsInStruct(pos) || this->IsInUnion(pos))
         {
         continue;
@@ -201,19 +201,19 @@ bool Parser::CheckInternalVariables(const char* regEx,bool alignment,bool checkP
     previouspos = 0;
     while(pos != std::string::npos)
       {
-      std::string var = this->FindInternalVariable(pos+1,privateLast,pos); 
+      std::string var = this->FindInternalVariable(pos+1,privateLast,pos);
       if(var == "")
         {
         continue;
         }
-      
+
       if(this->IsInStruct(pos) || this->IsInUnion(pos))
         {
         continue;
         }
 
       if(var.length() > 0)
-        {  
+        {
         // Check the alignment if specified
         if(alignment)
           {
@@ -257,11 +257,11 @@ bool Parser::CheckInternalVariables(const char* regEx,bool alignment,bool checkP
           }
         }
       }
-    
+
     classPosBegin = this->GetClassPosition(classPosBegin+1);
-    
+
     } // End loop class pos
-    
+
   return !hasError;
 }
 
@@ -272,7 +272,7 @@ std::string Parser::FindInternalVariable(size_t start, size_t end,size_t & pos)
   while(posSemicolon != std::string::npos && posSemicolon<end)
     {
     // We try to find the word before that
-    long i=static_cast<long>(posSemicolon)-1;
+    unsigned long i=static_cast<unsigned long>(posSemicolon)-1;
     bool inWord = true;
     bool first = false;
     std::string ivar = "";
@@ -359,10 +359,7 @@ std::string Parser::FindInternalVariable(size_t start, size_t end,size_t & pos)
      }
 
     std::string subphrase = "";
-    if(i>=0)
-      {
-      subphrase = m_BufferNoComment.substr(i+1,posSemicolon-i-1);
-      }
+    subphrase = m_BufferNoComment.substr(i+1,posSemicolon-i-1);
 
     if( (subphrase.find("=") == std::string::npos)
       && (subphrase.find("(") == std::string::npos)


### PR DESCRIPTION
- Updated the boost library with the latest release version (August 13th, 2015 15:23 GMT)

- Fixed warning message of KWStyle which were discovered with the following flags:
  -Wunused-parameter -Wformat-nonliteral -Wdisabled-macro-expansion -Wno-sign-compare -Wtautological-compare

- Removed the following warning messages:

    -/Utilities/KWSys/CommandLineArguments.cxx:616:23: warning: format string is not a string literal [-Wformat-nonliteral]
      sprintf(buffer, format, argument);
                            ^~~~~~
1 warning generated.

/Utilities/boost/optional.hpp:15:
/boost/optional/optional.hpp:1254:53: warning: 
      unused parameter 'out' [-Wunused-parameter]
operator<<(std::basic_ostream<CharType, CharTrait>& out, optional_detail::optional_tag const& v)
                                                    ^
/Utilities/boost/optional/optional.hpp:1254:95: warning: 
      unused parameter 'v' [-Wunused-parameter]
operator<<(std::basic_ostream<CharType, CharTrait>& out, optional_detail::optional_tag const& v)
                                                                                                                                                          ^

/kwsRunKWStyleTest.cxx:24:27: warning: unused parameter 'argc' [-Wunused-parameter]
int kwsRunKWStyleTest(int argc, char* argv[] )
                          ^

kwsCheckInternalVariables.cxx:362: warning: comparison of unsigned expression >= 0 is always true [-Wtautological-compare]
    if(i>=0)
       ~^ ~