### PR TITLE
COMP: Fixed additional warning messages (unused-local-typedef and disabled-macro-expansion)

### DIFF
--- a/Utilities/boost/concept_check.hpp
+++ b/Utilities/boost/concept_check.hpp
@@ -38,6 +38,9 @@
 # pragma warning( disable : 4610 ) // object 'class' can never be instantiated - user-defined constructor required
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#endif
 namespace boost
 {
 

--- a/Utilities/boost/fusion/support/detail/result_of.hpp
+++ b/Utilities/boost/fusion/support/detail/result_of.hpp
@@ -20,6 +20,10 @@
 #include <boost/mpl/has_xxx.hpp>
 #endif
 
+#if defined(__clang__)
+#pragma clang diagnostic ignored "-Wdisabled-macro-expansion"
+#endif
+
 namespace boost { namespace fusion { namespace detail
 {
     // This is a temporary workaround for result_of before we make fusion fully

--- a/Utilities/boost/static_assert.hpp
+++ b/Utilities/boost/static_assert.hpp
@@ -1,6 +1,6 @@
 //  (C) Copyright John Maddock 2000.
-//  Use, modification and distribution are subject to the 
-//  Boost Software License, Version 1.0. (See accompanying file 
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 //  See http://www.boost.org/libs/static_assert for documentation.
@@ -67,7 +67,7 @@
 //
 // If the compiler warns about unused typedefs then enable this:
 //
-#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7)))
+#if defined(__GNUC__) && ((__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 7))) || (defined(__apple_build_version__) && (__apple_build_version__ >= 7000000))
 #  define BOOST_STATIC_ASSERT_UNUSED_ATTRIBUTE __attribute__((unused))
 #else
 #  define BOOST_STATIC_ASSERT_UNUSED_ATTRIBUTE
@@ -135,13 +135,13 @@ template<int x> struct static_assert_test{};
       sizeof(::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST (__VA_ARGS__) >)>\
          BOOST_JOIN(boost_static_assert_typedef_, __COUNTER__)
 #elif (defined(BOOST_INTEL_CXX_VERSION) || defined(BOOST_SA_GCC_WORKAROUND))  && defined(BOOST_NO_CXX11_VARIADIC_MACROS)
-// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error 
+// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error
 // instead of warning in case of failure
 # define BOOST_STATIC_ASSERT( B ) \
     typedef char BOOST_JOIN(boost_static_assert_typedef_, __LINE__) \
         [ ::boost::STATIC_ASSERTION_FAILURE< BOOST_STATIC_ASSERT_BOOL_CAST( B ) >::value ]
 #elif (defined(BOOST_INTEL_CXX_VERSION) || defined(BOOST_SA_GCC_WORKAROUND))  && !defined(BOOST_NO_CXX11_VARIADIC_MACROS)
-// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error 
+// agurt 15/sep/02: a special care is needed to force Intel C++ issue an error
 // instead of warning in case of failure
 # define BOOST_STATIC_ASSERT(...) \
     typedef char BOOST_JOIN(boost_static_assert_typedef_, __LINE__) \


### PR DESCRIPTION
- Fixed warning messages of disabled-macro-expansion from result_of.hpp
- Fixed unused-local-typedef warning message from static_assert.hpp
- Removed unused-local-typedef warning message from concept_check.hpp
 