### PR TITLE
COMP: Fix the addition warning messages of boost library

### DIFF
--- a/Utilities/boost/concept_check.hpp
+++ b/Utilities/boost/concept_check.hpp
@@ -39,8 +39,9 @@
 #endif
 
 #if defined(__clang__)
-#pragma clang diagnostic ignored "-Wunused-local-typedef"
+#pragma clang diagnostic ignored "-Wall"
 #endif
+
 namespace boost
 {
 
@@ -1079,6 +1080,7 @@ namespace boost
 #if (defined _MSC_VER)
 # pragma warning( pop )
 #endif
+
 
 # include <boost/concept/detail/concept_undef.hpp>
 

--- a/Utilities/boost/xpressive/detail/dynamic/parse_charset.hpp
+++ b/Utilities/boost/xpressive/detail/dynamic/parse_charset.hpp
@@ -301,8 +301,8 @@ inline void parse_charset
         case token_posix_charset_begin:
             {
                 FwdIter tmp = begin, start = begin;
-                bool invert = (token_charset_invert == tr.get_charset_token(tmp, end));
-                if(invert)
+                bool localinvert = (token_charset_invert == tr.get_charset_token(tmp, end));
+                if(localinvert)
                 {
                     begin = start = tmp;
                 }
@@ -315,7 +315,7 @@ inline void parse_charset
                 {
                     char_class_type chclass = rxtraits.lookup_classname(start, tmp, icase);
                     BOOST_XPR_ENSURE_(0 != chclass, error_ctype, "unknown class name");
-                    chset.set_class(chclass, invert);
+                    chset.set_class(chclass, localinvert);
                     continue;
                 }
                 begin = iprev; // un-get this token

--- a/Utilities/boost/xpressive/detail/dynamic/parser_traits.hpp
+++ b/Utilities/boost/xpressive/detail/dynamic/parser_traits.hpp
@@ -388,16 +388,16 @@ private:
     regex_constants::compiler_token_type parse_mods_(FwdIter &begin, FwdIter end)
     {
         using namespace regex_constants;
-        bool set = true;
+        bool localset = true;
         do switch(*begin)
         {
-        case BOOST_XPR_CHAR_(char_type, 'i'): this->flag_(set, icase_); break;
-        case BOOST_XPR_CHAR_(char_type, 'm'): this->flag_(!set, single_line); break;
-        case BOOST_XPR_CHAR_(char_type, 's'): this->flag_(!set, not_dot_newline); break;
-        case BOOST_XPR_CHAR_(char_type, 'x'): this->flag_(set, ignore_white_space); break;
+        case BOOST_XPR_CHAR_(char_type, 'i'): this->flag_(localset, icase_); break;
+        case BOOST_XPR_CHAR_(char_type, 'm'): this->flag_(!localset, single_line); break;
+        case BOOST_XPR_CHAR_(char_type, 's'): this->flag_(!localset, not_dot_newline); break;
+        case BOOST_XPR_CHAR_(char_type, 'x'): this->flag_(localset, ignore_white_space); break;
         case BOOST_XPR_CHAR_(char_type, ':'): ++begin; BOOST_FALLTHROUGH;
         case BOOST_XPR_CHAR_(char_type, ')'): return token_no_mark;
-        case BOOST_XPR_CHAR_(char_type, '-'): if(false == (set = !set)) break; BOOST_FALLTHROUGH;
+        case BOOST_XPR_CHAR_(char_type, '-'): if(false == (localset = !localset)) break; BOOST_FALLTHROUGH;
         default: BOOST_THROW_EXCEPTION(regex_error(error_paren, "unknown pattern modifier"));
         }
         while(BOOST_XPR_ENSURE_(++begin != end, error_paren, "incomplete extension"));
@@ -408,9 +408,9 @@ private:
 
     ///////////////////////////////////////////////////////////////////////////////
     // flag_
-    void flag_(bool set, regex_constants::syntax_option_type flag)
+    void flag_(bool localset, regex_constants::syntax_option_type flag)
     {
-        this->flags_ = set ? (this->flags_ | flag) : (this->flags_ & ~flag);
+        this->flags_ = localset ? (this->flags_ | flag) : (this->flags_ & ~flag);
     }
 
     ///////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
- Fixed unused-local-typedef and unknown-pragmas warning
   - Removed unused-local-typedef and unknown-pragmas warning messages by
     adding the following macros:

      #if defined(__clang__)
      #pragma clang diagnostic ignored "-Wall"
      #endif

- Fixed shadow warning messages
   - Removed the shadow warning messages by creating local variables
     at the reported functions