### PR TITLE
COMP: Fix the addition warning messages of boost library

### DIFF
--- a/Utilities/boost/concept_check.hpp
+++ b/Utilities/boost/concept_check.hpp
@@ -38,8 +38,10 @@
 # pragma warning( disable : 4610 ) // object 'class' can never be instantiated - user-defined constructor required
 #endif
 
-#if defined(__clang__)
-#pragma clang diagnostic ignored "-Wall"
+#if defined(__clang__) && defined(__has_warning)
+# if __has_warning("-Wunused-local-typedef")
+#  pragma clang diagnostic ignored "-Wunused-local-typedef"
+# endif
 #endif
 
 namespace boost


### PR DESCRIPTION
- Fixed unused-local-typedef and unknown-pragmas warning
   - Removed unused-local-typedef and unknown-pragmas warning messages by
     adding the following macros:

      #if defined(__clang__)
      #pragma clang diagnostic ignored "-Wall"
      #endif

- Fixed shadow warning messages
   - Removed the shadow warning messages by creating local variables
     at the reported functions