### PR TITLE
COMP: Fix format-string warning messages on VS14

### DIFF
--- a/kwsCheckMemberFunctions.cxx
+++ b/kwsCheckMemberFunctions.cxx
@@ -157,7 +157,7 @@ bool Parser::CheckMemberFunctions(const char* regEx,unsigned long maxLength)
               error.number = MEMBERFUNCTION_LENGTH;
               error.description = "function (" + memberFunction + ") has too many lines: ";
               char* temp = new char[10];
-              sprintf(temp,"%ld",lclose-lopen);
+              sprintf(temp,"%zd",lclose-lopen);
               error.description += temp;
               error.description += " (";
               sprintf(temp,"%ld",maxLength);
@@ -255,7 +255,7 @@ bool Parser::CheckMemberFunctions(const char* regEx,unsigned long maxLength)
                error.number = MEMBERFUNCTION_LENGTH;
                error.description = "function (" + functionName + ") has too many lines: ";
                char* temp = new char[10];
-               sprintf(temp,"%ld",lclose-lopen);
+               sprintf(temp,"%zd",lclose-lopen);
                error.description += temp;
                error.description += " (";
                sprintf(temp,"%ld",maxLength);

--- a/kwsCheckTypedefs.cxx
+++ b/kwsCheckTypedefs.cxx
@@ -110,10 +110,10 @@ bool Parser::CheckTypedefs(const char* regEx, bool alignment,unsigned int maxLen
             error.number = TYPEDEF_ALIGN;
             error.description = "Type definition (" + var + ") is not aligned with the previous one: ";
             char* localvar = new char[10];
-            sprintf(localvar,"%ld",l);
+            sprintf(localvar,"%zd",l);
             error.description += localvar;
             error.description += " v.s. ";
-            sprintf(localvar,"%ld",previouspos);
+            sprintf(localvar,"%zd",previouspos);
             error.description += localvar;
             delete [] localvar;
             m_ErrorList.push_back(error);


### PR DESCRIPTION
- Fix warning messages of format-string on VS 14.
- These warning messages were reported at the following page:
  https://open.cdash.org/viewBuildError.php?type=1&buildid=4117158