### PR TITLE
ENH: Include filename with error message on dashboard reports

### DIFF
--- a/kwsGenerator.cxx
+++ b/kwsGenerator.cxx
@@ -1188,6 +1188,8 @@ bool Generator::GenerateDart(const char* dir,int maxError,
         file << "          <Text>";
         }
 
+      file << sourcefile.c_str();
+      file << " : ";
       file << (*it).GetErrorTag((*itError).number);
       file << " : ";
       std::string desc = (*itError).description;


### PR DESCRIPTION
Some dashboard reports display errors without listing the sourcefile, this
fix prepends the filename to each error line.

Compare old:
   https://open.cdash.org/viewBuildError.php?buildid=4154911
with new:
   https://open.cdash.org/viewBuildError.php?buildid=4154987

New mimics how errors are reported from compilation builds.