### PR TITLE
BUG: KWStyle was not checking if string was between single quotes

### DIFF
--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -1475,8 +1475,26 @@ bool Parser::IsValidQuote(std::string & stream,size_t pos) const
   return false;
 }
 
+/**  return true if the position pos is between ' ' */
+bool Parser::IsBetweenSingleQuote(size_t pos,bool withComments,std::string buffer) const
+{
+  return this->IsBetweenQuoteChar(pos,withComments,buffer,'\'');
+}
+
 /**  return true if the position pos is between " " */
+bool Parser::IsBetweenDoubleQuote(size_t pos,bool withComments,std::string buffer) const
+{
+  return this->IsBetweenQuoteChar(pos,withComments,buffer,'"');
+}
+
+/**  return true if the position pos is between " " or ' ' */
 bool Parser::IsBetweenQuote(size_t pos,bool withComments,std::string buffer) const
+{
+  return (this->IsBetweenQuoteChar(pos,withComments,buffer,'\'') || this->IsBetweenQuoteChar(pos,withComments,buffer,'"'));
+}
+
+/**  return true if the position pos is between the selected quoteChar (should be ' or ") */
+bool Parser::IsBetweenQuoteChar(size_t pos,bool withComments,std::string buffer, char quoteChar) const
 {
   std::string stream = buffer;
 
@@ -1495,16 +1513,16 @@ bool Parser::IsBetweenQuote(size_t pos,bool withComments,std::string buffer) con
     }
 
   // We don't want to check for \" otherwise it fails
-  size_t b0 = stream.find('"',0);
+  size_t b0 = stream.find(quoteChar,0);
   while((b0!=std::string::npos) && !this->IsValidQuote(stream,b0))
     {
-    b0 = stream.find('"',b0+1);
+    b0 = stream.find(quoteChar,b0+1);
     }
 
-  size_t b1 = stream.find('"',b0+1);
+  size_t b1 = stream.find(quoteChar,b0+1);
   while((b1!=std::string::npos) && !this->IsValidQuote(stream,b1))
     {
-    b1 = stream.find('"',b1+1);
+    b1 = stream.find(quoteChar,b1+1);
     }
 
   while(b0 != std::string::npos && b1 != std::string::npos && b1>b0)
@@ -1513,16 +1531,16 @@ bool Parser::IsBetweenQuote(size_t pos,bool withComments,std::string buffer) con
       {
       return true;
       }
-    b0 = stream.find('"',b1+1);
+    b0 = stream.find(quoteChar,b1+1);
     while((b0!=std::string::npos) && !this->IsValidQuote(stream,b0))
       {
-      b0 = stream.find('"',b0+1);
+      b0 = stream.find(quoteChar,b0+1);
       }
 
-    b1 = stream.find('"',b0+1);
+    b1 = stream.find(quoteChar,b0+1);
     while((b1!=std::string::npos) && !this->IsValidQuote(stream,b1))
       {
-      b1 = stream.find('"',b1+1);
+      b1 = stream.find(quoteChar,b1+1);
       }
     }
   return false;

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -333,8 +333,14 @@ public:
   void SetFixFile(bool fix) {m_FixFile = fix;}
   void GenerateFixedFile();
 
-  /**  return true if the position pos is between " " */
+  /**  return true if the position pos is between " " or ' ' */
   bool IsBetweenQuote(size_t pos,bool withComments=false,std::string buffer="") const;
+
+  /**  return true if the position pos is between ' ' */
+  bool IsBetweenSingleQuote(size_t pos,bool withComments=false,std::string buffer="") const;
+
+  /**  return true if the position pos is between " " */
+  bool IsBetweenDoubleQuote(size_t pos,bool withComments=false,std::string buffer="") const;
 
 protected:
 
@@ -399,6 +405,9 @@ protected:
    *  The Fast version just check for <test> and not for <test<>,test<>>*/
   bool IsBetweenCharsFast(const char begin, const char end, size_t pos,bool withComments=false,std::string buffer="") const;
   bool IsBetweenChars(const char begin, const char end, size_t pos,bool withComments=false,std::string buffer="") const;
+
+  /** Return true if the position pos is between the selected quote character (' or ") */
+  bool IsBetweenQuoteChar(size_t pos,bool withComments,std::string buffer, char quoteChar) const;
 
   bool IsValidQuote(std::string & stream,size_t pos) const;
 


### PR DESCRIPTION
KWStyle was only checking if string was in between double quotes. This
patch forces KWStyle to also check if the string is in between single
quotes.
Previously, the following code:
  writer->SetFieldDelimiterCharacter( ',' );

would not be accepted by KWStyle if the style sheet was expecting
a space before or after a comma. This is a problem in C++ since
adding a comma between the single quote marks would change the meaning
of the code.