### PR TITLE
Bugfix: checkIndent never set \t as indent character

### DIFF
--- a/kwsCheckIndent.cxx
+++ b/kwsCheckIndent.cxx
@@ -154,7 +154,7 @@ bool Parser::CheckIndent(IndentType itype,
     }
 
   char type = ' ';
-  if(itype == (IndentType)TABS) {type = '\t';}
+  if(itype == kws::TAB) {type = '\t';}
 
   int wantedIndent = 0;
 


### PR DESCRIPTION
itype is a enum variable of type Indentype, assuming values SPACE (=0) and TAB (=1).
Default tab character was "space", but when itype = TAB the conditional expression
 if(itype == (IndentType)TABS) 
always evaluates to false (IndentType)TABS equals 10).