### PR TITLE
BUG: Single quote check incorrect if a single quote used within a string

### DIFF
--- a/Testing/CMakeLists.txt
+++ b/Testing/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(KWSTYLE_TESTS  ${CXX_TEST_PATH}/KWStyleTests)
 
 SET(
  KWStyleTests_SRCS
+ kwsIndentTest.cxx
  kwsSemiColonSpaceTest.cxx
  kwsStatementPerLineTest.cxx
  kwsVariablePerLineTest.cxx

--- a/Testing/KWStyleTests.cxx
+++ b/Testing/KWStyleTests.cxx
@@ -16,6 +16,7 @@
 
 void RegisterTests()
 {
+  REGISTER_TEST(kwsIndentTest);
   REGISTER_TEST(kwsSemiColonSpaceTest);
   REGISTER_TEST(kwsStatementPerLineTest);
   REGISTER_TEST(kwsVariablePerLineTest);

--- a/Testing/kwsIndentTest.cxx
+++ b/Testing/kwsIndentTest.cxx
@@ -1,0 +1,92 @@
+/*=========================================================================
+
+  Program:   Insight Segmentation & Registration Toolkit
+  Module:    kwsVariablePerLineTest.cxx
+  Language:  C++
+  Date:      $Date$
+  Version:   $Revision$
+
+  Copyright (c) Insight Software Consortium. All rights reserved.
+  See ITKCopyright.txt or http://www.itk.org/HTML/Copyright.htm for details.
+
+     This software is distributed WITHOUT ANY WARRANTY; without even 
+     the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR 
+     PURPOSE.  See the above copyright notices for more information.
+
+=========================================================================*/
+#if defined(_MSC_VER)
+#pragma warning ( disable : 4786 )
+#endif
+
+#include "kwsParser.h"
+
+int kwsIndentTest(int, char* [] )
+{
+  std::string buffer;
+  buffer = "int main(int argc, argv)\r\n{\r\n   int a;\r\n}";
+
+  kws::Parser parser;
+  parser.SetBuffer(buffer);
+  parser.Check("LineLength","999");
+  parser.Check("Indent","SPACE,2,true,true");
+
+  // Test for bad syntax
+  std::cout << "Test for bad syntax: ";
+  kws::Parser::ErrorVectorType errors = parser.GetErrors();
+  if(errors.size() > 0)
+    {
+    for(unsigned int i=0;i<errors.size();i++)
+      {
+      std::cout << errors[i].description << std::endl;
+      }
+    }
+  else
+    {
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
+  // Test for good syntax
+  buffer = "int main(int argc, argv)\r\n{\r\n  int a;\r\n}";
+  parser.ClearErrors();
+  parser.SetBuffer(buffer);
+  parser.Check("LineLength","999");
+  parser.Check("Indent","SPACE,2,true,true");
+
+  std::cout << "Test for good syntax: ";
+  errors = parser.GetErrors();
+  if(errors.size() > 0)
+    {
+    for(unsigned int i=0;i<errors.size();i++)
+      {
+      std::cout << errors[i].description << std::endl;
+      }
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
+  // Test for good syntax
+  buffer = "int main(int argc, argv)\r\n{\r\n  std::string x(\"my string's test\");\r\n  for(;;)\r\n    {\r\n    }\r\n  int a;\r\n}";
+  parser.ClearErrors();
+  parser.SetBuffer(buffer);
+  parser.Check("LineLength","999");
+  parser.Check("Indent","SPACE,2,true,true");
+
+  std::cout << "Test for good syntax: ";
+  errors = parser.GetErrors();
+  if(errors.size() > 0)
+    {
+    for(unsigned int i=0;i<errors.size();i++)
+      {
+      std::cout << errors[i].description << std::endl;
+      std::cout << "Line = " << errors[i].line << std::endl;
+      }
+    std::cout << "[FAILED]" << std::endl;
+    return EXIT_FAILURE;
+    }
+  std::cout << "[PASSED]" << std::endl;
+
+  return 0;
+}

--- a/kwsCheckIndent.cxx
+++ b/kwsCheckIndent.cxx
@@ -613,11 +613,27 @@ bool Parser::CheckIndent(IndentType itype,
         if(this->GetLineNumber(doubleslash) == this->GetLineNumber(pos))
           {
           check = false;
+          std::cout << "Ignored }" << std::endl;
+          std::cout << " Line = " << this->GetLineNumber(pos) << std::endl;
+          std::cout << " Doubleslash" << std::endl;
           }
         }
       if(check)
         {
         wantedIndent -= size;
+        }
+      }
+    else
+      {
+      if((it != m_Buffer.end()) && ((*it) == '}')
+         && !sindent )
+        {
+        std::cout << "Ignored }" << std::endl;
+        std::cout << " Line = " << this->GetLineNumber(pos) << std::endl;
+        std::cout << " IsInAnyCommnets = " << this->IsInAnyComments(pos)
+          << std::endl;
+        std::cout << " IsBetweenQuote = " << this->IsBetweenQuote(
+          this->GetPositionWithoutComments(pos),false) << std::endl;
         }
       }
 

--- a/kwsCheckIndent.cxx
+++ b/kwsCheckIndent.cxx
@@ -613,27 +613,11 @@ bool Parser::CheckIndent(IndentType itype,
         if(this->GetLineNumber(doubleslash) == this->GetLineNumber(pos))
           {
           check = false;
-          std::cout << "Ignored }" << std::endl;
-          std::cout << " Line = " << this->GetLineNumber(pos) << std::endl;
-          std::cout << " Doubleslash" << std::endl;
           }
         }
       if(check)
         {
         wantedIndent -= size;
-        }
-      }
-    else
-      {
-      if((it != m_Buffer.end()) && ((*it) == '}')
-         && !sindent )
-        {
-        std::cout << "Ignored }" << std::endl;
-        std::cout << " Line = " << this->GetLineNumber(pos) << std::endl;
-        std::cout << " IsInAnyCommnets = " << this->IsInAnyComments(pos)
-          << std::endl;
-        std::cout << " IsBetweenQuote = " << this->IsBetweenQuote(
-          this->GetPositionWithoutComments(pos),false) << std::endl;
         }
       }
 

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -1478,7 +1478,39 @@ bool Parser::IsValidQuote(std::string & stream,size_t pos) const
 /**  return true if the position pos is between ' ' */
 bool Parser::IsBetweenSingleQuote(size_t pos,bool withComments,std::string buffer) const
 {
-  return this->IsBetweenQuoteChar(pos,withComments,buffer,'\'');
+  std::string stream = buffer;
+
+  if(pos == std::string::npos)
+    {
+    return false;
+    }
+
+  if(pos == 0)
+    {
+    return false;
+    }
+
+  if(buffer.size()==0)
+    {
+    stream = m_BufferNoComment;
+    if(withComments)
+      {
+      stream = m_Buffer;
+      }
+    }
+
+  if(pos == 1 && stream[0] != '\'')
+    {
+    return false;
+    }
+
+  if(pos == stream.length()-1)
+    {
+    return false;
+    }
+
+  return ( ( stream[pos-1] == '\'' || ( stream[pos-1] == '\\' &&
+       stream[pos-2] == '\'' ) ) && stream[pos+1] == '\'' );
 }
 
 /**  return true if the position pos is between " " */
@@ -1490,7 +1522,8 @@ bool Parser::IsBetweenDoubleQuote(size_t pos,bool withComments,std::string buffe
 /**  return true if the position pos is between " " or ' ' */
 bool Parser::IsBetweenQuote(size_t pos,bool withComments,std::string buffer) const
 {
-  return (this->IsBetweenQuoteChar(pos,withComments,buffer,'\'') || this->IsBetweenQuoteChar(pos,withComments,buffer,'"'));
+  return ( this->IsBetweenSingleQuote(pos,withComments,buffer) ||
+    this->IsBetweenDoubleQuote(pos,withComments,buffer) );
 }
 
 /**  return true if the position pos is between the selected quoteChar (should be ' or ") */


### PR DESCRIPTION
Previously would erroneously consider distant ' to be relevant to determining if a character was within 's

The logic intended to identify when a key character (e.g., a } or a { ) was within single quotes, indicating that it should be ignored.   However, it did this by counting the number of single quotes occurring before the key character.  So, if a single quote was used within a quote to indicated the possessive form of a noun, then the entire system was thrown off.   Specifically, the following code would through an error (incorrectly).

int main(int argc, char *argv[])
{
   std::string x("This is my's string");
   for(;;)
    {
    }
  int a;
}

Where the "int a" is flagged as needing to be indented by 4, because the } was being ignored since it was thought to be inside of a set of ' (see "my's" substring in the string definition).

New version just checks for '<key>' and '\<key>'  when testing if <key> is within single quotes (that is, it only looks for valid/relevant single char (and escaped single character) instances.