### PR TITLE
BUG: Must run IsBetweenChars and IsBetweenCharFast to cover all options

### DIFF
--- a/kwsCheckVariablePerLine.cxx
+++ b/kwsCheckVariablePerLine.cxx
@@ -82,7 +82,9 @@ bool Parser::CheckVariablePerLine(unsigned long max)
 
         // If we have any '(' in the line we stop
         if( !this->IsBetweenChars( '(', ')', posType, false ) &&
-          !this->IsBetweenChars( '<', '>', posType, false ))
+          !this->IsBetweenCharsFast( '(', ')', posType, false ) &&
+          !this->IsBetweenChars( '<', '>', posType, false ) &&
+          !this->IsBetweenCharsFast( '<', '>', posType, false ))
           {
           // This is a very simple check we count the number of comas
           unsigned int vars = 1;
@@ -90,7 +92,9 @@ bool Parser::CheckVariablePerLine(unsigned long max)
           while(pos!=-1)
             {
             posType = m_BufferNoComment.find(',', posType+1);
-            if( !this->IsBetweenCharsFast( '(', ')', posType, false ) &&
+            if( !this->IsBetweenChars( '(', ')', posType, false ) &&
+              !this->IsBetweenCharsFast( '(', ')', posType, false ) &&
+              !this->IsBetweenChars( '<', '>', posType, false ) &&
               !this->IsBetweenCharsFast( '<', '>', posType, false ))
               {
               // Check that we are not initializing an array


### PR DESCRIPTION
KWStyle standard (e.g., used in kwsCheckIndent and kwsCheckOperator) is to call IsBetweenChars and IsBetweenCharsFast to verify all conditions of being between parens.  

Calling only IsBetweenChars( '(', ')' ...) would fail to detect the comma being in between parens in this case:

    int main ( int itkNotUsed( argc ), char * itkNotUsed( argv )[] )

or anything of similar format of adjacent parens nested within a set of parens.

Calling both IsBetweenChars and IsBetweenCharsFast resolves these and other cases encountered.

Probably need to revise implementation of both to instead have one that provides a definitive answer.