### PR TITLE
COMP: Params first and second shadowed member variables.  Renamed.

### DIFF
--- a/Utilities/boost/xpressive/sub_match.hpp
+++ b/Utilities/boost/xpressive/sub_match.hpp
@@ -81,8 +81,8 @@ public:
     {
     }
 
-    sub_match(BidiIter first, BidiIter second, bool matched_ = false)
-      : std::pair<BidiIter, BidiIter>(first, second)
+    sub_match(BidiIter iterFirst, BidiIter iterSecond, bool matched_ = false)
+      : std::pair<BidiIter, BidiIter>(iterFirst, iterSecond)
       , matched(matched_)
     {
     }


### PR DESCRIPTION
KWStyle/Utilities/boost/xpressive/sub_match.hpp:84:5: warning: declaration of ‘first’ shadows a member of ‘boost::xpressive::sub_match<__gnu_cxx::__normal_iterator > >’ [-Wshadow]
     sub_match(BidiIter first, BidiIter second, bool matched_ = false)

KWStyle/Utilities/boost/xpressive/sub_match.hpp:84:5: warning: declaration of ‘second’ shadows a member of ‘boost::xpressive::sub_match<__gnu_cxx::__normal_iterator > >’ [-Wshadow]
     sub_match(BidiIter first, BidiIter second, bool matched_ = false)

