### PR TITLE
ENH: Allow for spaces after commas at the end of lines in macros.

### DIFF
--- a/kwsCheckComma.cxx
+++ b/kwsCheckComma.cxx
@@ -55,7 +55,8 @@ bool Parser::CheckComma( unsigned int before, unsigned int after )
       }
     if( i<(long int)m_BufferNoComment.size()
         && ( m_BufferNoComment[i] == '\n' ||
-             m_BufferNoComment[i] == '\r' ) )
+             m_BufferNoComment[i] == '\r' ||
+             m_BufferNoComment[i] == '\\' ) )
       {
       aft = after;
       }

--- a/kwsCheckIndent.cxx
+++ b/kwsCheckIndent.cxx
@@ -451,7 +451,7 @@ bool Parser::CheckIndent(IndentType itype,
         std::string previousLine = this->GetLine(this->GetLineNumber(pos)-2);
         std::string currentLine = this->GetLine(this->GetLineNumber(pos)-1);
         if(( (previousLine[previousLine.size()-1] != ';')
-           && (previousLine.size()+currentLine.size()-currentIndent>maxLength))
+           && (previousLine.size()+currentLine.size()-currentIndent>0.9*maxLength))
           || (isInsideEnum)
           )
           {


### PR DESCRIPTION
Also, allow wrapping+indent in cases where the line length is less
than 90% of the max line length (instead of only allowing wrapping
+ indent if the line would exceed the maximum line length).