### PR TITLE
COMP: Set the minimum required CMake version to 3.10.2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,11 @@
 
 language: cpp
 
+osx_image: xcode10.1
+
+before_install:
+  - brew install cmake
+
 os:
   - linux
   - osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.4)
+cmake_minimum_required(VERSION 3.10.2)
 
 foreach(p
     CMP0003

--- a/Utilities/KWSys/CMakeLists.txt
+++ b/Utilities/KWSys/CMakeLists.txt
@@ -75,7 +75,7 @@
 # any outside mailing list and no documentation of the change will be
 # written.
 
-cmake_minimum_required(VERSION 2.6.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10.2 FATAL_ERROR)
 if(POLICY CMP0025)
   CMAKE_POLICY(SET CMP0025 NEW)
 endif()


### PR DESCRIPTION
As agreed in:
https://discourse.itk.org/t/cmake-update/870/

Set the `cmake_minimum_required` to version **3.10.2**.