### PR TITLE
Fix/remove dependence on lineLength check

### DIFF
--- a/Testing/kwsBadCharactersTest.cxx
+++ b/Testing/kwsBadCharactersTest.cxx
@@ -31,7 +31,6 @@ int kwsBadCharactersTest(int, char* [] )
 
   kws::Parser parser;
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("BadCharacters","true");
 
   // Test for bad syntax
@@ -55,7 +54,6 @@ int kwsBadCharactersTest(int, char* [] )
   buffer = "void()\n{\n  //testäüöß;\n};";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   // the point is that now we don't check in comments
   parser.Check("BadCharacters","false");
 

--- a/Testing/kwsIndentTest.cxx
+++ b/Testing/kwsIndentTest.cxx
@@ -27,7 +27,6 @@ int kwsIndentTest(int, char* [] )
 
   kws::Parser parser;
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("Indent","SPACE,2,true,true");
 
   // Test for bad syntax
@@ -51,7 +50,6 @@ int kwsIndentTest(int, char* [] )
   buffer = "int main(int argc, argv)\r\n{\r\n  int a;\r\n}";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("Indent","SPACE,2,true,true");
 
   std::cout << "Test for good syntax: ";
@@ -71,7 +69,6 @@ int kwsIndentTest(int, char* [] )
   buffer = "int main(int argc, argv)\r\n{\r\n  std::string x(\"my string's test\");\r\n  for(;;)\r\n    {\r\n    }\r\n  int a;\r\n}";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("Indent","SPACE,2,true,true");
 
   std::cout << "Test for good syntax: ";

--- a/Testing/kwsStatementPerLineTest.cxx
+++ b/Testing/kwsStatementPerLineTest.cxx
@@ -27,7 +27,6 @@ int kwsStatementPerLineTest(int, char* [] )
 
   kws::Parser parser;
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("StatementPerLine","1");
 
   // Test for bad syntax
@@ -51,7 +50,6 @@ int kwsStatementPerLineTest(int, char* [] )
   buffer = "Test1();\r\nTest2();";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("StatementPerLine","1");
 
   std::cout << "Test for good syntax: ";
@@ -71,7 +69,6 @@ int kwsStatementPerLineTest(int, char* [] )
   buffer = "for(int i=0;i<3;i++)";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("StatementPerLine","1");
 
   std::cout << "Test for good syntax: ";

--- a/Testing/kwsSwitchCaseTest.cxx
+++ b/Testing/kwsSwitchCaseTest.cxx
@@ -27,7 +27,6 @@ int kwsSwitchCaseTest(int, char* [] )
 
   kws::Parser parser;
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("Indent","SPACE,2,true,true");
 
   // Test for bad syntax
@@ -51,7 +50,6 @@ int kwsSwitchCaseTest(int, char* [] )
   buffer = "void()\n{\n  test;\n};";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("Indent","SPACE,2,true,true");
 
   std::cout << "Test for good syntax: ";

--- a/Testing/kwsVariablePerLineTest.cxx
+++ b/Testing/kwsVariablePerLineTest.cxx
@@ -27,7 +27,6 @@ int kwsVariablePerLineTest(int, char* [] )
 
   kws::Parser parser;
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("VariablePerLine","1");
 
   // Test for bad syntax
@@ -51,7 +50,6 @@ int kwsVariablePerLineTest(int, char* [] )
   buffer = "int a;\r\nint b;";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("VariablePerLine","1");
 
   std::cout << "Test for good syntax: ";
@@ -71,7 +69,6 @@ int kwsVariablePerLineTest(int, char* [] )
   buffer = "int a,b;";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("VariablePerLine","2");
 
   std::cout << "Test for good syntax: ";
@@ -91,7 +88,6 @@ int kwsVariablePerLineTest(int, char* [] )
   buffer = "template < int t,\r\nint x, int c > foo;";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("VariablePerLine","1");
 
   std::cout << "Test for good syntax: ";
@@ -110,7 +106,6 @@ int kwsVariablePerLineTest(int, char* [] )
   buffer = "void func( int t,\r\n  int x, int c, \r\n  int d );";
   parser.ClearErrors();
   parser.SetBuffer(buffer);
-  parser.Check("LineLength","999");
   parser.Check("VariablePerLine","1");
 
   std::cout << "Test for good syntax: ";

--- a/kwsCheckLineLength.cxx
+++ b/kwsCheckLineLength.cxx
@@ -17,7 +17,7 @@ namespace kws {
 
 
 /** Check the number of character per line */
-bool Parser::CheckLineLength(unsigned long max,bool checkHeader)
+bool Parser::CheckLineLength(unsigned long max,bool checkHeader, bool doErrorCheck)
 {
   m_TestsDone[LINE_LENGTH] = true;
   char* val = new char[255];
@@ -75,7 +75,7 @@ bool Parser::CheckLineLength(unsigned long max,bool checkHeader)
       m_Positions.push_back(cc);
       line_end = static_cast<long int>(cc);
       long int line_length = line_end - line_start-1;
-      if(line_length > (long int)max && cc>fileSize)
+      if(doErrorCheck && (line_length > (long int)max && cc>fileSize))
         {
         Error error;
         error.line = line_count;

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -56,6 +56,10 @@ bool Parser::Check(const char* name, const char* value)
     this->CheckLineLength(atoi(value));
     return true;
     }
+  else if(m_Positions.empty())
+    {
+    this->CheckLineLength(0,false,false); // run CheckLineLength without errors to fill m_Positions
+    }
   if(!strcmp(name,"DeclarationOrder"))
     {
     this->CheckDeclarationOrder(atoi(&value[0]),atoi(&value[2]),atoi(&value[4]));

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -238,7 +238,7 @@ public:
   bool CheckIfWhileForUntil( unsigned int spaces );
 
   /** Check the number of character per line */
-  bool CheckLineLength(unsigned long max,bool checkHeader=false);
+  bool CheckLineLength(unsigned long max,bool checkHeader=false, bool doErrorCheck=true);
 
   /** Check if the internal parameters of the class are correct */
   bool CheckInternalVariables(const char* regEx,bool alignement = true,bool checkProtected=false);


### PR DESCRIPTION
 Fix/remove dependence on lineLength check for correct line numbers and VariablePerLine checks, fixes #48, fixes #60, fixes #82