### PR TITLE
Run tests when building on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,5 @@ addons:
 script:
   - mkdir build-clang
   - mkdir build-gcc
-  - cd build-clang && CC=clang CXX=clang++ cmake .. && make && cd ..
-  - cd build-gcc   && CC=gcc   CXX=g++     cmake .. && make && cd ..
+  - cd build-clang && CC=clang CXX=clang++ cmake .. && make && make test && cd ..
+  - cd build-gcc   && CC=gcc   CXX=g++     cmake .. && make && make test && cd ..


### PR DESCRIPTION
Currently, failing tests are not detected when building on Travis CI, because they are not executed. Add “make test” for both builds.