### PR TITLE
COMP: fix potential buffer overflow

### DIFF
--- a/kwsCheckFunctions.cxx
+++ b/kwsCheckFunctions.cxx
@@ -29,7 +29,7 @@ bool Parser::CheckFunctions(const char* regEx,unsigned long maxLength)
     {
     m_TestsDone[FUNCTION_LENGTH] = true;
     m_TestsDescription[FUNCTION_LENGTH] = "Functions must not exceed: ";
-    char* temp = new char[10];
+    char* temp = new char[22];
     sprintf(temp,"%ld",maxLength);
     m_TestsDescription[FUNCTION_LENGTH] += temp;
     m_TestsDescription[FUNCTION_LENGTH] += " lines";
@@ -160,7 +160,7 @@ bool Parser::CheckFunctions(const char* regEx,unsigned long maxLength)
           error.line2 = efl;
           error.number = FUNCTION_LENGTH;
           error.description = "function (" + functionName + ") has too many lines: ";
-          char* temp = new char[10];
+          char* temp = new char[22];
           sprintf(temp,"%ld",efl-bfl);
           error.description += temp;
           error.description += " (";


### PR DESCRIPTION
warning: '%ld' directive writing between 1 and 20 bytes into a region of size 10 [-Wformat-overflow=]
note: '__builtin___sprintf_chk' output between 2 and 21 bytes into a destination of size 10