### PR TITLE
COMP: Type not C-compatible due to non-POD member

### DIFF
--- a/kwsParser.h
+++ b/kwsParser.h
@@ -118,24 +118,25 @@ const char ErrorTag[NUMBER_ERRORS][4] = {
    {'P','R','N','\0'}
   };
 
-
-typedef struct
+struct ErrorStruct
   {
   unsigned long line; // main line of the error
   unsigned long line2; // second line of error if the error is covering several lines
   unsigned long number;
   std::string description; 
-  } Error;
+  };
+using Error = struct ErrorStruct;
 
-typedef struct
+struct WarningStruct
   {
   unsigned long line; // main line of the warning
   unsigned long line2; // second line of warning if the warning is covering several lines
   unsigned long number;
   std::string description; 
-  } Warning;
+  };
+using Warning = struct WarningStruct;
 
-typedef struct
+struct IndentPositionStruct
   {
   // Position in the file
   size_t position;
@@ -147,7 +148,8 @@ typedef struct
   int after;
   // Name of the current ident
   std::string name;
-  } IndentPosition;
+  };
+using IndentPosition = struct IndentPositionStruct;
 
 class Parser
 {


### PR DESCRIPTION
KWStyle/kwsParser.h:127 col 5: note: type is given name 'Error' for linkage purposes by this typedef declaration
KWStyle/kwsParser.h:136 col 5: note: type is given name 'Warning' for linkage purposes by this typedef declaration
KWStyle/kwsParser.h:151 col 5: note: type is given name 'IndentPosition' for linkage purposes by this typedef declaration

warning: anonymous non-C-compatible type given name for linkage purposes
by typedef declaration; add a tag name here [-Wnon-c-typedef-for-linkage]

note: type is not C-compatible due to this member declaration