### PR TITLE
COMP: Explicit size_t to long conversion

### DIFF
--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -425,7 +425,7 @@ bool Parser::Check(const char* name, const char* value)
     std::string val = value;
     std::string v1 = value;
     bool uppercaseTheDefinition = false;
-    long pos = val.find(",", 0);
+    const long pos = static_cast<long>(val.find(",", 0));
     if(pos != -1)
       {
       v1 = val.substr(0, pos);
@@ -445,7 +445,7 @@ bool Parser::Check(const char* name, const char* value)
   else if(!strcmp(name,"Operator"))
     {
     std::string val = value;
-    long pos = static_cast<long>(val.find(",",0));
+    const long pos = static_cast<long>(val.find(",",0));
     if(pos == -1)
       {
       std::cout << "Operator not defined correctly" << std::endl;
@@ -458,7 +458,7 @@ bool Parser::Check(const char* name, const char* value)
   else if(!strcmp(name,"Comma"))
     {
     std::string val = value;
-    long pos = static_cast<long>(val.find(",",0));
+    const long pos = static_cast<long>(val.find(",",0));
     if(pos == -1)
       {
       std::cout << "Comma not defined correctly" << std::endl;


### PR DESCRIPTION
Use static_cast like the other entries. Also add const.

To address:

  D:\a\1\s-build\KWStyle\kwsParser.cxx(428): warning C4267: 'initializing': conversion from 'size_t' to 'long', possible loss of data
