### PR TITLE
Fix format overflow warning

### DIFF
--- a/kwsCheckExtraSpaces.cxx
+++ b/kwsCheckExtraSpaces.cxx
@@ -69,16 +69,13 @@ bool Parser::CheckExtraSpaces(unsigned long max,bool checkEmptyLines)
             error.line2 = error.line;
             error.number = SPACES;
             error.description = "Number of spaces before end of line exceed: ";
-            char* localval = new char[10];
+            char localval[21];
             sprintf(localval,"%ld",space);
             error.description += localval;
             error.description += " (max=";
-            delete [] localval;
-            localval = new char[10];
             sprintf(localval,"%ld",max);
             error.description += localval;
             error.description += ")";
-            delete [] localval;
             m_ErrorList.push_back(error);
             hasError = true;
             break; // avoid multiple error line

--- a/kwsCheckLineLength.cxx
+++ b/kwsCheckLineLength.cxx
@@ -79,16 +79,13 @@ bool Parser::CheckLineLength(unsigned long max,bool checkHeader, bool doErrorChe
         error.line2 = error.line;
         error.number = LINE_LENGTH;
         error.description = "Line length exceed ";
-        char* localval = new char[10];
+        char localval[21];
         sprintf(localval,"%ld",line_length);
         error.description += localval;
         error.description += " (max=";
-        delete [] localval;
-        localval = new char[10];
         sprintf(localval,"%ld",max);
         error.description += localval;
         error.description += ")";
-        delete [] localval;
         m_ErrorList.push_back(error);
         hasError = true;
         }


### PR DESCRIPTION
Example message:

KWStyle/kwsCheckLineLength.cxx:83:27: warning: '%ld' directive writing between 1 and 20 bytes into a region of size 10 [-Wformat-overflow=]