### PR TITLE
BUG: fix reported version number

### DIFF
--- a/KWStyleConfigure.h.in
+++ b/KWStyleConfigure.h.in
@@ -11,7 +11,4 @@
      PURPOSE.  See the above copyright notices for more information.
 
 =========================================================================*/
-#define KWSTYLE_MAJOR_VERSION "@KWStyle_MAJOR_VERSION@"
-#define KWSTYLE_MINOR_VERSION "@KWStyle_MINOR_VERSION@"
-#define KWSTYLE_PATCH_VERSION "@KWStyle_PATCH_VERSION@"
-#define KWSTYLE_VERSION_STRING "@KWStyle_MAJOR_VERSION@.@KWStyle_MINOR_VERSION@.@KWStyle_PATCH_VERSION@"
+#define KWSTYLE_VERSION_STRING "@KWStyle_VERSION@"


### PR DESCRIPTION
This partially reverts commit c8344295940410ec482a92e7f19b72ca5277da3c `ENH: Use modern project command.`

It caused version to not be properly reported:
```text
$ KWStyle.exe -version
Version: ..
```
Now:
```text
$ KWStyle.exe -version
Version: 1.1.0
```
Closes #102.