### PR TITLE
COMP: Do not use -Wdeprecated-copy ignore pragma with clang

### DIFF
--- a/Utilities/boost/proto/expr.hpp
+++ b/Utilities/boost/proto/expr.hpp
@@ -132,7 +132,7 @@ namespace boost { namespace proto
         // actually defined:
         #include <boost/proto/detail/basic_expr.hpp>
 
-        #if defined(__GNUC__) && __GNUC__ >= 9 || defined(__clang__) && __clang_major__ >= 10
+        #if defined(__GNUC__) && __GNUC__ >= 9
             #pragma GCC diagnostic push
             // The warning cannot be fixed for aggregates
             // Sadly, GCC currently emits the warning at the use location:
@@ -144,7 +144,7 @@ namespace boost { namespace proto
         // actually defined:
         #include <boost/proto/detail/expr.hpp>
 
-        #if defined(__GNUC__) && __GNUC__ >= 9 || defined(__clang__) && __clang_major__ >= 10
+        #if defined(__GNUC__) && __GNUC__ >= 9
             #pragma GCC diagnostic pop
         #endif
     }


### PR DESCRIPTION
With Apple clang version 12.0.0, this throws:

  KWStyle/Utilities/boost/proto/expr.hpp:140:44: warning: unknown
  warning group '-Wdeprecated-copy', ignored [-Wunknown-warning-option]