### PR TITLE
COMP: Ignore clang predefined-identifier-outside-function warning

### DIFF
--- a/Utilities/boost/throw_exception.hpp
+++ b/Utilities/boost/throw_exception.hpp
@@ -7,6 +7,15 @@
 # pragma once
 #endif
 
+#if defined(__clang__)
+# if defined(__has_warning)
+#  if __has_warning("-Wpredefined-identifier-outside-function")
+#   pragma clang diagnostic push
+#   pragma clang diagnostic ignored "-Wpredefined-identifier-outside-function"
+#  endif
+# endif
+#endif
+
 //  boost/throw_exception.hpp
 //
 //  Copyright (c) 2002, 2018-2022 Peter Dimov


### PR DESCRIPTION
Silence:

```
In file included from /home/matt/src/KWStyle/Utilities/boost/smart_ptr/detail/shared_count.hpp:31:
/home/matt/src/KWStyle/Utilities/boost/throw_exception.hpp:233:105: warning: predefined identifier is only valid inside function [-Wpredefined-identifier-outside-function]
template<class E> BOOST_NORETURN void throw_with_location( E && e, boost::source_location const & loc = BOOST_CURRENT_LOCATION )
                                                                                                        ^
/home/matt/src/KWStyle/Utilities/boost/assert/source_location.hpp:104:79: note: expanded from macro 'BOOST_CURRENT_LOCATION'
                                                                              ^
/home/matt/src/KWStyle/Utilities/boost/current_function.hpp:37:33: note: expanded from macro 'BOOST_CURRENT_FUNCTION'
```

That is being thrown following: https://github.com/Kitware/KWStyle/pull/111
