### PR TITLE
Use POSIX standard technique for testing existance of a command

### DIFF
--- a/Utilities/updateBoost.sh
+++ b/Utilities/updateBoost.sh
@@ -24,9 +24,8 @@ die()
 ## Validate ##
 required_commands=( git grep dirname basename cat )
 for required_command in ${required_commands[@]}; do
-  $required_command --version >/dev/null 2>&1
-  if [[ $? -ne 0 ]]; then
-    die "Command \"$required_command\" not found"
+  if ! command -v $required_command &> /dev/null; then
+      die "Command \"$required_command\" not found"
   fi
 done
 


### PR DESCRIPTION
Fixes issue #73.

macOS dirname does not have a `--version` option, which was making the script fail on macOS.

This technique should be POSIX compliant and more crossplatform.

Solution taken from:

https://stackoverflow.com/questions/592620/how-can-i-check-if-a-program-exists-from-a-bash-script