### PR TITLE
Make all files valid UTF8

### DIFF
--- a/kwsCheckBadCharacters.cxx
+++ b/kwsCheckBadCharacters.cxx
@@ -18,7 +18,7 @@ using namespace boost::xpressive;
 
 namespace kws {
 
-/** Check if the current file as bad characters like δόφί*/
+/** Check if the current file has bad characters */
 bool Parser::CheckBadCharacters(bool checkComments)
 {
   m_TestsDone[BADCHARACTERS] = true;


### PR DESCRIPTION
Clang warned:

```
kwsCheckBadCharacters.cxx:21:54: warning: invalid UTF-8 in comment [-Winvalid-utf8]
/** Check if the current file as bad characters like <E4><FC><F6><DF>*/
                                                     ^
```

The example in the comment doesn't really add anything, so just removed it.

The C++ standards committee is looking to make UTF-8 the standard portable encoding for C++ (P2295R5), so it's best that files be valid UTF-8.

There was also a test file with invalid characters, though there it was deliberate to test KWStyle's ability to detect such characters. Instead, the non-UTF8 sequences are now inserted via their hex equilavent.  Added an additional test that tried both true/false to include/exclude comment checks.

Removed pragmas that suppress warnings, now that everything is valid UTF-8.

Made some tweaks to the examples text to more resemble real C (no trailing semi, added newline).