### PR TITLE
removed parser Destructor

### DIFF
--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -38,7 +38,6 @@ Parser::Parser()
 }
 
 /** Destructor */
-Parser::~Parser() = default;
 
 /** To be able to use std::sort we provide the < operator */
 bool Parser::operator<(const Parser& a) const

--- a/kwsParser.cxx
+++ b/kwsParser.cxx
@@ -37,7 +37,6 @@ Parser::Parser()
 
 }
 
-/** Destructor */
 
 /** To be able to use std::sort we provide the < operator */
 bool Parser::operator<(const Parser& a) const

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -158,7 +158,6 @@ public:
   /** Constructor */
   Parser();
 
-  /** Destructor */
 
   /** To be able to use std::sort we provide the < operator */
   bool operator<(const Parser& a) const;

--- a/kwsParser.h
+++ b/kwsParser.h
@@ -159,7 +159,6 @@ public:
   Parser();
 
   /** Destructor */
-  ~Parser();
 
   /** To be able to use std::sort we provide the < operator */
   bool operator<(const Parser& a) const;


### PR DESCRIPTION
removed the destructor since it didn't have copy constructor and copy assignment and there was no implementation for destructor.
it was causing -Wdeprecated-copy-with-user-provided-dtor in clang