### PR TITLE
fixed implicit-int-conversion warning in clang and added to_string mehod for maxlength (size_t)

### DIFF
--- a/kwsCheckIfNDefDefine.cxx
+++ b/kwsCheckIfNDefDefine.cxx
@@ -176,7 +176,7 @@ bool Parser::CheckIfNDefDefine(const char* match, bool uppercaseTheDefinition)
       if(uppercaseTheDefinition)
         {
         for(std::string::iterator it = toMatch.begin(); it != toMatch.end(); it++)
-          *it = std::toupper(*it);
+          *it = static_cast<char>(std::toupper(*it));
         }
 
       if(ifndef != toMatch)

--- a/kwsCheckMemberFunctions.cxx
+++ b/kwsCheckMemberFunctions.cxx
@@ -26,7 +26,7 @@ bool Parser::CheckMemberFunctions(const char* regEx,unsigned long maxLength)
     {
     m_TestsDone[MEMBERFUNCTION_LENGTH] = true;
     m_TestsDescription[MEMBERFUNCTION_LENGTH] = "Member functions must not exceed: ";
-    m_TestsDescription[MEMBERFUNCTION_LENGTH] += maxLength;
+    m_TestsDescription[MEMBERFUNCTION_LENGTH] += std::to_string(maxLength);
     m_TestsDescription[MEMBERFUNCTION_LENGTH] += " lines";
     }
 


### PR DESCRIPTION
the problem with previous one was i had a typo. it was std::string instead of std::to_string. it compiles in clang and passes the tests for me