### PR TITLE
resolved clang W-undef warnings

### DIFF
--- a/metaCommand.h
+++ b/metaCommand.h
@@ -29,6 +29,10 @@
 #include <list>
 #include <map>
 
+#ifndef METAIO_USE_NAMESPACE
+#define METAIO_USE_NAMESPACE 0
+#endif
+
 #if (METAIO_USE_NAMESPACE)
 namespace METAIO_NAMESPACE {
 #endif


### PR DESCRIPTION
added define for METAIO_USE_NAMESPACE. I wasn't sure if it was intended to be ifdef or if so I didn't change it